### PR TITLE
Refactor AutoPlayer to Fabric event flow

### DIFF
--- a/src/client/java/com/autotrap/AutoplayerClient.java
+++ b/src/client/java/com/autotrap/AutoplayerClient.java
@@ -1,0 +1,61 @@
+package com.autotrap;
+
+import com.example.autoplayer.AutoPlayerMod;
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
+import org.lwjgl.glfw.GLFW;
+
+/**
+ * Fabric client entrypoint for the AutoPlayer automation system.
+ */
+public final class AutoplayerClient implements ClientModInitializer {
+
+    private AutoPlayerMod autoPlayerMod;
+    private KeyBinding toggleAutomationKey;
+
+    @Override
+    public void onInitializeClient() {
+        autoPlayerMod = new AutoPlayerMod();
+        autoPlayerMod.initialize();
+        registerKeybindings();
+        registerEvents();
+    }
+
+    private void registerKeybindings() {
+        toggleAutomationKey = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+                "key.autoplayer.toggle",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_P,
+                "category.autoplayer.controls"));
+    }
+
+    private void registerEvents() {
+        ClientTickEvents.END_CLIENT_TICK.register(this::onClientTick);
+        HudRenderCallback.EVENT.register((drawContext, tickDelta) -> {
+            if (autoPlayerMod.isInitialized()) {
+                autoPlayerMod.renderHud();
+            }
+        });
+        ClientLifecycleEvents.CLIENT_STOPPING.register(client -> {
+            if (autoPlayerMod.isInitialized()) {
+                autoPlayerMod.saveState();
+            }
+        });
+    }
+
+    private void onClientTick(MinecraftClient client) {
+        if (!autoPlayerMod.isInitialized()) {
+            return;
+        }
+        if (toggleAutomationKey.wasPressed()) {
+            autoPlayerMod.toggleAutomation();
+        }
+        autoPlayerMod.tick();
+    }
+}

--- a/src/main/java/com/example/autoplayer/task/TaskScheduler.java
+++ b/src/main/java/com/example/autoplayer/task/TaskScheduler.java
@@ -55,10 +55,9 @@ public class TaskScheduler {
     }
 
     public void tick() {
-        context.getKeybindHandler().poll();
         context.getSafetyManager().tick(context);
         if (!context.getConfig().isEnabled()) {
-            context.getHud().render(context, null);
+            context.getStateMachine().tick(context);
             return;
         }
         if (currentTask == null && currentIndex < tasks.size()) {
@@ -66,7 +65,6 @@ public class TaskScheduler {
         }
         if (currentTask != null) {
             currentTask.tick(context);
-            context.getHud().render(context, currentTask);
             if (currentTask.isComplete(context)) {
                 currentTask.onComplete(context);
                 completedTasks.add(currentTask.getName());
@@ -80,8 +78,6 @@ public class TaskScheduler {
                     progressPersistence.saveCompletedTasks(completedTasks, "");
                 }
             }
-        } else {
-            context.getHud().render(context, null);
         }
         context.getStateMachine().tick(context);
     }
@@ -102,5 +98,9 @@ public class TaskScheduler {
 
     public Set<String> getCompletedTaskNames() {
         return new HashSet<>(completedTasks);
+    }
+
+    public Optional<AutoPlayerTask> getCurrentTask() {
+        return Optional.ofNullable(currentTask);
     }
 }


### PR DESCRIPTION
## Summary
- replace the AutoPlayerMod blocking loop with event-driven initialization, ticking, and persistence helpers
- expose the scheduler state without direct HUD rendering so UI updates can be driven by Fabric callbacks
- add a Fabric client entrypoint that initializes AutoPlayerMod and wires client tick, HUD render, lifecycle, and keybinding handlers

## Testing
- ./gradlew check --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68cc0fa504008324b335a7377f370564