### PR TITLE
Update Fabric metadata and add client entrypoint

### DIFF
--- a/src/main/java/com/example/autoplayer/AutoPlayerClient.java
+++ b/src/main/java/com/example/autoplayer/AutoPlayerClient.java
@@ -1,0 +1,19 @@
+package com.example.autoplayer;
+
+import net.fabricmc.api.ClientModInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Fabric entrypoint that boots the automation mod when the Minecraft client starts.
+ */
+public final class AutoPlayerClient implements ClientModInitializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AutoPlayerClient.class);
+
+    @Override
+    public void onInitializeClient() {
+        LOGGER.info("Initializing AutoPlayer automation client");
+        new AutoPlayerMod().start();
+    }
+}

--- a/src/main/resources/autoplayer.mixins.json
+++ b/src/main/resources/autoplayer.mixins.json
@@ -1,11 +1,7 @@
 {
-  "required": true,
-  "package": "com.autotrap.mixin",
+  "required": false,
+  "package": "com.example.autoplayer.mixin",
   "compatibilityLevel": "JAVA_17",
-  "client": [
-    "GameRendererMixin",
-    "MinecraftClientMixin"
-  ],
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,16 +16,16 @@
   "environment": "client",
   "entrypoints": {
     "main": [
-      "com.autotrap.AutoplayerClient"
+      "com.example.autoplayer.AutoPlayerClient"
     ]
   },
   "mixins": [
     "autoplayer.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
-    "minecraft": ">=1.20.1",
-    "fabric-api": ">=0.91.0"
+    "fabricloader": ">=0.16.7",
+    "minecraft": "1.21.8",
+    "fabric-api": ">=0.108.0+1.21.8"
   },
   "custom": {
     "loom:generated": true


### PR DESCRIPTION
## Summary
- point the fabric main entrypoint at the new AutoPlayerClient class and align dependency versions with Minecraft 1.21.8
- clean up the mixin configuration to reference the actual package and drop unused client mixins
- add a ClientModInitializer entrypoint that boots the existing AutoPlayerMod when the client initializes

## Testing
- ./gradlew --console=plain check

------
https://chatgpt.com/codex/tasks/task_e_68cc0fa18f0c8324bd760cb0d6f408a2