### PR TITLE
Add start wrapper for AutoPlayerMod initialization

### DIFF
--- a/src/main/java/com/example/autoplayer/AutoPlayerMod.java
+++ b/src/main/java/com/example/autoplayer/AutoPlayerMod.java
@@ -36,6 +36,10 @@ public final class AutoPlayerMod {
         this.progressPersistence = new ProgressPersistence();
     }
 
+    public void start() {
+        initialize();
+    }
+
     public void initialize() {
         if (initialized) {
             return;


### PR DESCRIPTION
## Summary
- add a simple `start` wrapper method on `AutoPlayerMod` so existing entrypoints continue to work

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cc26785a708324966daa0768fb9fa0