### PR TITLE
Update packaged mixin config to match source

### DIFF
--- a/build/resources/main/autoplayer.mixins.json
+++ b/build/resources/main/autoplayer.mixins.json
@@ -1,11 +1,7 @@
 {
-  "required": true,
-  "package": "com.autotrap.mixin",
+  "required": false,
+  "package": "com.example.autoplayer.mixin",
   "compatibilityLevel": "JAVA_17",
-  "client": [
-    "GameRendererMixin",
-    "MinecraftClientMixin"
-  ],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
## Summary
- align the packaged `autoplayer.mixins.json` with the source configuration so the client mixin list is removed and metadata matches the `com.example.autoplayer.mixin` package

## Testing
- `./gradlew --console=plain clean build` *(fails: existing unit tests are failing; see build log for details)*
- `./gradlew --console=plain runClient`


------
https://chatgpt.com/codex/tasks/task_e_68cc37c8004083249d5141d14163d230